### PR TITLE
Updated some old and unhelpful URLs

### DIFF
--- a/chrome.md
+++ b/chrome.md
@@ -9,9 +9,9 @@ permalink: /chrome/
 
 ## Bugtracker for webplatform bugs
 
-There is a [Bugtracker](https://code.google.com/p/chromium/issues/list) to report bugs for Chrome.
+There is a [Bugtracker](https://crbug.com) to report bugs for Chrome.
 
-To open a [new bug](http://chromiumbugs.appspot.com/?continue=https%3A//code.google.com/p/chromium/issues/entry.do) you need to sign in with a Google account.
+To open a [new bug](https://crbug.com/wizard) you need to sign in with a Google account.
 
 ## Guidelines
 


### PR DESCRIPTION
Specifically, the new bug URL led to an unhelpful page that tells you to go back and sign in and that would never be true in this case.
crbug.com is a handy short URL that leads to the right place, regardless of switching domains and paths.